### PR TITLE
rename vredis to redis

### DIFF
--- a/redis.v
+++ b/redis.v
@@ -1,4 +1,4 @@
-module vredis
+module redis
 
 import net
 import strconv

--- a/redis_test.v
+++ b/redis_test.v
@@ -1,4 +1,4 @@
-module vredis
+module redis
 
 fn setup() Redis {
 	redis := connect(ConnOpts{}) or { panic(err) }


### PR DESCRIPTION
Module name and the entrypoint should be the same name.

fixes #14 